### PR TITLE
Refactor DCAT extras handling in harvest / rdf parsing

### DIFF
--- a/udata/core/dataset/rdf.py
+++ b/udata/core/dataset/rdf.py
@@ -508,9 +508,8 @@ def infer_dataset_access_rights(resources_access_rights: list[set]) -> set | Non
     """
     if not resources_access_rights:
         return
-    first_set = resources_access_rights[0]
-    if all(x == first_set for x in resources_access_rights):
-        return first_set
+    if resources_access_rights[0] == set.intersection(*resources_access_rights):
+        return resources_access_rights[0]
 
 
 def add_dcat_extra(

--- a/udata/core/dataset/rdf.py
+++ b/udata/core/dataset/rdf.py
@@ -619,7 +619,6 @@ def dataset_from_rdf(graph: Graph, dataset=None, node=None):
     if temporal_coverage:
         dataset.temporal_coverage = temporal_from_rdf(d.value(DCT.temporal))
 
-    # Adding some metadata to extras - may be moved to property if relevant
     provenance = rdf_values(d, DCT.provenance, parse_label=True)
     if provenance:
         add_dcat_extra(dataset, "provenance", provenance)

--- a/udata/core/dataset/rdf.py
+++ b/udata/core/dataset/rdf.py
@@ -36,8 +36,8 @@ from udata.rdf import (
     TAG_TO_EU_HVD_CATEGORIES,
     contact_point_from_rdf,
     namespace_manager,
+    rdf_unique_values,
     rdf_value,
-    rdf_values,
     remote_url_from_rdf,
     sanitize_html,
     schema_from_rdf,
@@ -473,7 +473,7 @@ def access_rights_from_rdf(resource: RdfResource) -> set[str]:
     Extract the access rights from a RdfResource
     Cardinality is 0..n (although it should be 0..1 per the spec).
     """
-    return rdf_values(resource, DCT.accessRights, parse_label=True)
+    return rdf_unique_values(resource, DCT.accessRights, parse_label=True)
 
 
 def licenses_from_rdf(resource: RdfResource) -> set[str]:
@@ -482,7 +482,7 @@ def licenses_from_rdf(resource: RdfResource) -> set[str]:
     See `test_dataset_rdf.py > test_licenses_from_rdf` for examples of supported formats.
     Cardinality is 0..n (although it should be 0..1 per the spec).
     """
-    return rdf_values(resource, DCT.license, parse_label=True)
+    return rdf_unique_values(resource, DCT.license, parse_label=True)
 
 
 def rights_from_rdf(resource: RdfResource) -> set[str]:
@@ -490,7 +490,7 @@ def rights_from_rdf(resource: RdfResource) -> set[str]:
     Extract rights from a RDF distribution.
     Cardinality is 0..n.
     """
-    return rdf_values(resource, DCT.rights, parse_label=True)
+    return rdf_unique_values(resource, DCT.rights, parse_label=True)
 
 
 def provenances_from_rdf(resource: RdfResource) -> set[str]:
@@ -498,7 +498,7 @@ def provenances_from_rdf(resource: RdfResource) -> set[str]:
     Extract provenance from a RDF distribution.
     Cardinality is 0..n.
     """
-    return rdf_values(resource, DCT.provenance, parse_label=True)
+    return rdf_unique_values(resource, DCT.provenance, parse_label=True)
 
 
 def infer_dataset_access_rights(resources_access_rights: list[set]) -> set | None:

--- a/udata/core/dataset/rdf.py
+++ b/udata/core/dataset/rdf.py
@@ -625,12 +625,12 @@ def dataset_from_rdf(graph: Graph, dataset=None, node=None):
             **dataset.extras.get("harvest", {}),
         }
 
-    resources_licenses = set()
+    resources_licenses_hints = set()
     for distrib in d.objects(DCAT.distribution | DCAT.distributions):
         resource_from_rdf(distrib, dataset)
         # include both dct:license and dct:rights as licenses hints from resources
-        resources_licenses |= licenses_from_rdf(distrib)
-        resources_licenses |= rights_from_rdf(distrib)
+        resources_licenses_hints |= licenses_from_rdf(distrib)
+        resources_licenses_hints |= rights_from_rdf(distrib)
 
     # assign the distribution accessRights to the dataset if all distribs that have an accessRights have the same accessRights
     # and the dataset doesn't have accessRights
@@ -671,7 +671,7 @@ def dataset_from_rdf(graph: Graph, dataset=None, node=None):
         dataset_canonical_license,
         *dataset_licenses,
         *dataset_rights,
-        *resources_licenses,
+        *resources_licenses_hints,
         default=default_license,
     )
 

--- a/udata/core/dataset/rdf.py
+++ b/udata/core/dataset/rdf.py
@@ -632,6 +632,9 @@ def dataset_from_rdf(graph: Graph, dataset=None, node=None):
         resources_licenses_hints |= licenses_from_rdf(distrib)
         resources_licenses_hints |= rights_from_rdf(distrib)
 
+    for additionnal in d.objects(DCT.hasPart):
+        resource_from_rdf(additionnal, dataset, is_additionnal=True)
+
     # assign the common resources accessRights to the dataset if it doesn't have accessRights
     dataset_access_rights = access_rights_from_rdf(d)
     if not dataset_access_rights and resources_access_rights:
@@ -639,11 +642,7 @@ def dataset_from_rdf(graph: Graph, dataset=None, node=None):
     if dataset_access_rights:
         add_dcat_extra(dataset, "accessRights", dataset_access_rights)
 
-    for additionnal in d.objects(DCT.hasPart):
-        resource_from_rdf(additionnal, dataset, is_additionnal=True)
-
     default_license = dataset.license or License.default()
-    dataset_canonical_license = rdf_value(d, DCT.license, parse_label=True)
     dataset_licenses = licenses_from_rdf(d)
     if dataset_licenses:
         add_dcat_extra(dataset, "license", dataset_licenses)
@@ -651,7 +650,6 @@ def dataset_from_rdf(graph: Graph, dataset=None, node=None):
     if dataset_rights:
         add_dcat_extra(dataset, "rights", dataset_rights)
     dataset.license = License.guess(
-        dataset_canonical_license,
         *dataset_licenses,
         *dataset_rights,
         *resources_licenses_hints,

--- a/udata/core/dataset/rdf.py
+++ b/udata/core/dataset/rdf.py
@@ -29,7 +29,6 @@ from udata.rdf import (
     FREQ,
     HVD_LEGISLATION,
     IANAFORMAT,
-    RDFS,
     SCHEMA,
     SCV,
     SKOS,
@@ -618,11 +617,11 @@ def dataset_from_rdf(graph: Graph, dataset=None, node=None):
         dataset.temporal_coverage = temporal_from_rdf(d.value(DCT.temporal))
 
     # Adding some metadata to extras - may be moved to property if relevant
-    provenance = [p.value(RDFS.label) for p in d.objects(DCT.provenance)]
+    provenance = rdf_values(d, DCT.provenance, parse_label=True)
     if provenance:
         dataset.extras["harvest"] = {
-            "dct:provenance": provenance,
             **dataset.extras.get("harvest", {}),
+            "dct:provenance": list(provenance),
         }
 
     resources_licenses_hints = set()

--- a/udata/harvest/tests/dcat/catalog.xml
+++ b/udata/harvest/tests/dcat/catalog.xml
@@ -75,6 +75,7 @@
     </dcat:dataset>
     <dcat:dataset>
       <dcat:Dataset rdf:about="http://data.test.org/datasets/2">
+        <dct:rights>Licence Ouverte Version 2.0</dct:rights>
         <dcat:keyword>Tag 1</dcat:keyword>
         <dcat:distribution rdf:resource="http://data.test.org/datasets/2/resources/1"/>
         <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-12-14T19:01:24.184120</dcterms:modified>
@@ -102,6 +103,7 @@
     <dcterms:title>Resource 2-2</dcterms:title>
     <dcterms:format>JSON</dcterms:format>
     <dcat:accessURL>http://data.test.org/datasets/2/resources/2/file.json</dcat:accessURL>
+    <dct:rights>Rights on nested resource</dct:rights>
   </dcat:Distribution>
   <vcard:Organization rdf:about="http://data.test.org/contacts/1">
     <vcard:fn>Organization contact</vcard:fn>

--- a/udata/harvest/tests/dcat/catalog.xml
+++ b/udata/harvest/tests/dcat/catalog.xml
@@ -94,25 +94,40 @@
         <dcterms:identifier>2</dcterms:identifier>
       </dcat:Dataset>
     </dcat:dataset>
+    <dcat:dataset>
+      <dcat:Dataset rdf:about="http://data.test.org/datasets/4">
+        <dct:rights>Licence Ouverte Version 2.0</dct:rights>
+        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-12-14T19:01:24.184120</dcterms:modified>
+        <dcterms:description>Dataset 4 description</dcterms:description>
+        <dcterms:publisher rdf:resource="http://data.test.org/organizations/1"/>
+        <owl:versionInfo>1.0</owl:versionInfo>
+        <dcat:landingPage>http://data.test.org/datasets/2</dcat:landingPage>
+        <dcat:distribution rdf:resource="http://data.test.org/datasets/4/resources/1"/>
+        <dcat:distribution rdf:resource="http://data.test.org/datasets/4/resources/2"/>
+        <dcterms:title>Dataset 2</dcterms:title>
+        <dcterms:identifier>4</dcterms:identifier>
+      </dcat:Dataset>
+    </dcat:dataset>
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-12-15T09:19:51.723691</dcterms:modified>
     <foaf:homepage>http://data.test.org</foaf:homepage>
     <dcterms:language>en</dcterms:language>
   </dcat:Catalog>
-  <dcat:Distribution rdf:about="http://data.test.org/datasets/2/resources/2">
-    <dcterms:description>A JSON resource</dcterms:description>
-    <dcterms:title>Resource 2-2</dcterms:title>
-    <dcterms:format>JSON</dcterms:format>
-    <dcat:accessURL>http://data.test.org/datasets/2/resources/2/file.json</dcat:accessURL>
-    <dct:rights>Rights on nested resource</dct:rights>
-  </dcat:Distribution>
   <vcard:Organization rdf:about="http://data.test.org/contacts/1">
     <vcard:fn>Organization contact</vcard:fn>
     <vcard:hasEmail>mailto: hello@its.me</vcard:hasEmail>
   </vcard:Organization>
+  <dcterms:PeriodOfTime rdf:about="file:///base/data/home/apps/s%7Erdf-translator/2.408516547054015808/temporal-1">
+    <schema:startDate rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-12-05T00:00:00</schema:startDate>
+  </dcterms:PeriodOfTime>
   <dcterms:PeriodOfTime rdf:about="file:///base/data/home/apps/s%7Erdf-translator/2.408516547054015808/temporal-2">
     <schema:startDate rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-01T00:00:00</schema:startDate>
     <schema:endDate rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-12-05T00:00:00</schema:endDate>
   </dcterms:PeriodOfTime>
+  <dcterms:Location rdf:about="http://wuEurope.com/"/>
+  <foaf:Organization rdf:about="http://data.test.org/organizations/1">
+    <foaf:name>An Organization</foaf:name>
+  </foaf:Organization>
+  <!-- resources for dataset 1 -->
   <dcat:Distribution rdf:about="http://data.test.org/datasets/1/resources/1">
     <dcterms:title>Resource 1-1</dcterms:title>
     <dcterms:format>
@@ -126,33 +141,52 @@
     <dcat:accessURL>http://data.test.org/datasets/1/resources/1/file.json</dcat:accessURL>
     <dct:license>Licence Ouverte Version 1.0</dct:license>
   </dcat:Distribution>
-  <dcterms:PeriodOfTime rdf:about="file:///base/data/home/apps/s%7Erdf-translator/2.408516547054015808/temporal-1">
-    <schema:startDate rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-12-05T00:00:00</schema:startDate>
-  </dcterms:PeriodOfTime>
   <dcat:Distribution rdf:about="http://data.test.org/datasets/1/resources/2">
     <dcterms:description>A JSON resource</dcterms:description>
     <dcterms:format>JSON</dcterms:format>
     <dcterms:title>Resource 1-2</dcterms:title>
     <dcat:accessURL>http://data.test.org/datasets/1/resources/2/file.json</dcat:accessURL>
   </dcat:Distribution>
+  <foaf:Document rdf:about="http://data.test.org/datasets/1/resources/3">
+    <dcterms:title>Resource 1-3</dcterms:title>
+    <dcterms:format>JSON</dcterms:format>
+  </foaf:Document>
+  <!-- resources for dataset 2 -->
   <dcat:Distribution rdf:about="http://data.test.org/datasets/2/resources/1">
     <dcat:accessURL>http://data.test.org/datasets/2/resources/1/file.json</dcat:accessURL>
     <dcterms:title>Resource 2-1</dcterms:title>
     <dcterms:format>JSON</dcterms:format>
     <dcterms:description>A JSON resource</dcterms:description>
   </dcat:Distribution>
+  <dcat:Distribution rdf:about="http://data.test.org/datasets/2/resources/2">
+    <dcterms:description>A JSON resource</dcterms:description>
+    <dcterms:title>Resource 2-2</dcterms:title>
+    <dcterms:format>JSON</dcterms:format>
+    <dcat:accessURL>http://data.test.org/datasets/2/resources/2/file.json</dcat:accessURL>
+    <dct:rights>Rights on nested resource</dct:rights>
+  </dcat:Distribution>
+  <!-- resources for dataset 3 -->
   <dcat:Distribution rdf:about="datasets/3/resources/1">
     <dcterms:format>JSON</dcterms:format>
     <dcterms:title>Resource 3-1</dcterms:title>
     <dcterms:description>A JSON resource</dcterms:description>
     <dcat:accessURL>http://data.test.org/datasets/3/resources/1/file.json</dcat:accessURL>
   </dcat:Distribution>
-  <foaf:Document rdf:about="http://data.test.org/datasets/1/resources/3">
-    <dcterms:title>Resource 1-3</dcterms:title>
+  <!-- resources for dataset 4 -->
+  <dcat:Distribution rdf:about="datasets/4/resources/1">
     <dcterms:format>JSON</dcterms:format>
-  </foaf:Document>
-  <dcterms:Location rdf:about="http://wuEurope.com/"/>
-  <foaf:Organization rdf:about="http://data.test.org/organizations/1">
-    <foaf:name>An Organization</foaf:name>
-  </foaf:Organization>
+    <dcterms:title>Resource 4-1</dcterms:title>
+    <dcterms:description>A JSON resource</dcterms:description>
+    <dcat:accessURL>http://data.test.org/datasets/4/resources/1/file.json</dcat:accessURL>
+    <dcat:accessRights>Access right 4</dcat:accessRights>
+    <dcat:accessRights>Access right 4-1</dcat:accessRights>
+  </dcat:Distribution>
+  <dcat:Distribution rdf:about="datasets/4/resources/2">
+    <dcterms:format>JSON</dcterms:format>
+    <dcterms:title>Resource 4-2</dcterms:title>
+    <dcterms:description>A JSON resource</dcterms:description>
+    <dcat:accessURL>http://data.test.org/datasets/4/resources/2/file.json</dcat:accessURL>
+    <dcat:accessRights>Access right 4</dcat:accessRights>
+    <dcat:accessRights>Access right 4-2</dcat:accessRights>
+  </dcat:Distribution>
 </rdf:RDF>

--- a/udata/harvest/tests/test_dcat_backend.py
+++ b/udata/harvest/tests/test_dcat_backend.py
@@ -502,10 +502,9 @@ class DcatBackendTest:
         assert dataset.temporal_coverage.start == date(2016, 1, 1)
         assert dataset.temporal_coverage.end == date(2016, 12, 5)
 
-        assert (
-            dataset.extras["harvest"]["dct:accessRights"]
-            == "http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/INSPIRE_Directive_Article13_1e"
-        )
+        assert dataset.extras["harvest"]["dct:accessRights"] == [
+            "http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/INSPIRE_Directive_Article13_1e"
+        ]
         assert dataset.extras["harvest"]["dct:provenance"] == [
             "Description de la provenance des données"
         ]
@@ -861,7 +860,7 @@ class CswIso19139DcatBackendTest:
         assert re.match(r"n[0-9a-f]{32}", resource.format)
 
         # accessRights is gotten from the only resource that is recognized as a distribution and copied to the dataset level
-        access_right = "Pas de restriction d'accès public selon INSPIRE"
+        access_right = ["Pas de restriction d'accès public selon INSPIRE"]
         assert dataset.extras["harvest"]["dct:accessRights"] == access_right
         # also present on the resource level
         assert resource.extras["harvest"]["dct:accessRights"] == access_right
@@ -898,7 +897,7 @@ class CswIso19139DcatBackendTest:
         assert dataset.license == lov1
 
         # accessRights is retrieved from the resources
-        access_right = "Pas de restriction d'accès public selon INSPIRE"
+        access_right = ["Pas de restriction d'accès public selon INSPIRE"]
         assert dataset.extras["harvest"]["dct:accessRights"] == access_right
         # also present on the resource level
         for resource in dataset.resources:

--- a/udata/harvest/tests/test_dcat_backend.py
+++ b/udata/harvest/tests/test_dcat_backend.py
@@ -557,6 +557,14 @@ class DcatBackendTest:
         resource_2 = next(res for res in dataset.resources if res.title == "Resource 2-2")
         assert resource_2.extras["dcat"]["rights"] == ["Rights on nested resource"]
 
+        # test different dct:accessRights on resources _not_ bubbling up to dataset
+        dataset = Dataset.objects.get(harvest__dct_identifier="4")
+        assert dataset.extras["dcat"].get("accessRights") is None
+        # test dct:accessRights storage in resource
+        for resource in dataset.resources:
+            assert len(resource.extras["dcat"]["accessRights"]) == 2
+            assert "Access right 4" in resource.extras["dcat"]["accessRights"]
+
     def test_geonetwork_xml_catalog(self, rmock):
         url = mock_dcat(rmock, "geonetwork.xml", path="catalog.xml")
         org = OrganizationFactory()

--- a/udata/harvest/tests/test_dcat_backend.py
+++ b/udata/harvest/tests/test_dcat_backend.py
@@ -502,12 +502,10 @@ class DcatBackendTest:
         assert dataset.temporal_coverage.start == date(2016, 1, 1)
         assert dataset.temporal_coverage.end == date(2016, 12, 5)
 
-        assert dataset.extras["harvest"]["dct:accessRights"] == [
+        assert dataset.extras["dcat"]["accessRights"] == [
             "http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/INSPIRE_Directive_Article13_1e"
         ]
-        assert dataset.extras["harvest"]["dct:provenance"] == [
-            "Description de la provenance des données"
-        ]
+        assert dataset.extras["dcat"]["provenance"] == ["Description de la provenance des données"]
 
         assert "observation-de-la-terre-et-environnement" in dataset.tags
         assert "hvd" in dataset.tags
@@ -553,11 +551,11 @@ class DcatBackendTest:
         # test dct:rights -> license support from dataset
         dataset = Dataset.objects.get(harvest__dct_identifier="2")
         assert dataset.license.id == "lov2"
-        assert dataset.extras["harvest"]["dct:rights"] == ["Licence Ouverte Version 2.0"]
+        assert dataset.extras["dcat"]["rights"] == ["Licence Ouverte Version 2.0"]
 
         # test dct:rights storage in resource
         resource_2 = next(res for res in dataset.resources if res.title == "Resource 2-2")
-        assert resource_2.extras["harvest"]["dct:rights"] == ["Rights on nested resource"]
+        assert resource_2.extras["dcat"]["rights"] == ["Rights on nested resource"]
 
     def test_geonetwork_xml_catalog(self, rmock):
         url = mock_dcat(rmock, "geonetwork.xml", path="catalog.xml")
@@ -861,15 +859,15 @@ class CswIso19139DcatBackendTest:
 
         # accessRights is gotten from the only resource that is recognized as a distribution and copied to the dataset level
         access_right = ["Pas de restriction d'accès public selon INSPIRE"]
-        assert dataset.extras["harvest"]["dct:accessRights"] == access_right
+        assert dataset.extras["dcat"]["accessRights"] == access_right
         # also present on the resource level
-        assert resource.extras["harvest"]["dct:accessRights"] == access_right
+        assert resource.extras["dcat"]["accessRights"] == access_right
 
         # see `test_geo_ide` for detailed explanation of the following
-        assert dataset.extras["harvest"].get("dct:license") is None
-        assert len(resource.extras["harvest"]["dct:license"]) == 6
-        assert dataset.extras["harvest"].get("dct:rights") is None
-        assert resource.extras["harvest"].get("dct:rights") is None
+        assert dataset.extras["dcat"].get("license") is None
+        assert len(resource.extras["dcat"]["license"]) == 6
+        assert dataset.extras["dcat"].get("rights") is None
+        assert resource.extras["dcat"].get("rights") is None
 
     def test_geo_ide(self):
         # this is the string used in geo-ide for now
@@ -898,20 +896,20 @@ class CswIso19139DcatBackendTest:
 
         # accessRights is retrieved from the resources
         access_right = ["Pas de restriction d'accès public selon INSPIRE"]
-        assert dataset.extras["harvest"]["dct:accessRights"] == access_right
+        assert dataset.extras["dcat"]["accessRights"] == access_right
         # also present on the resource level
         for resource in dataset.resources:
-            assert resource.extras["harvest"]["dct:accessRights"] == access_right
+            assert resource.extras["dcat"]["accessRights"] == access_right
 
         # _no_ licence extra on dataset level, since they're in resources
-        assert dataset.extras["harvest"].get("dct:license") is None
+        assert dataset.extras["dcat"].get("license") is None
         # all useLimitations have been duplicated on resources as dct:license
         for resource in dataset.resources:
-            r_licenses = resource.extras["harvest"]["dct:license"]
+            r_licenses = resource.extras["dcat"]["license"]
             assert len(r_licenses) == 6
             assert any("Licence Ouverte 1.0" in x for x in r_licenses)
 
         # no dct:rights anywhere, everything is in dct:license (at least for now)
-        assert dataset.extras["harvest"].get("dct:rights") is None
+        assert dataset.extras["dcat"].get("rights") is None
         for resource in dataset.resources:
-            assert resource.extras["harvest"].get("dct:rights") is None
+            assert resource.extras["dcat"].get("rights") is None

--- a/udata/migrations/2024-10-09-remove-extras-harvest.py
+++ b/udata/migrations/2024-10-09-remove-extras-harvest.py
@@ -29,7 +29,7 @@ def migrate(db):
         }
         for resource in dataset.resources:
             resource.extras = {
-                extra: resource.extras[extra] for extra in dataset.extras if extra != "harvest"
+                extra: resource.extras[extra] for extra in resource.extras if extra != "harvest"
             }
 
         try:

--- a/udata/migrations/2024-10-09-remove-extras-harvest.py
+++ b/udata/migrations/2024-10-09-remove-extras-harvest.py
@@ -1,0 +1,45 @@
+"""
+Remove all dataset and resources extras["harvest"] (they will be harvested as extras["dcat"] from now on)
+"""
+
+import logging
+
+from mongoengine.errors import ValidationError
+
+from udata.models import Dataset
+
+log = logging.getLogger(__name__)
+
+
+def migrate(db):
+    log.info("Processing Datasets.")
+
+    datasets = (
+        Dataset.objects(
+            __raw__={
+                "$or": [
+                    {"extras.harvest": {"$exists": True}},
+                ],
+            }
+        )
+        .no_cache()
+        .timeout(False)
+    )
+
+    datasets_count = datasets.count()
+    for dataset in datasets:
+        dataset.extras = {
+            extra: dataset.extras[extra] for extra in dataset.extras if extra != "harvest"
+        }
+        for resource in dataset.resources:
+            resource.extras = {
+                extra: resource.extras[extra] for extra in dataset.extras if extra != "harvest"
+            }
+
+        try:
+            dataset.save()
+        except ValidationError as e:
+            log.error(f"Failed to save dataset {dataset.id}: {e}")
+
+    log.info(f"Modified {datasets_count} datasets objects")
+    log.info("Done")

--- a/udata/migrations/2024-10-09-remove-extras-harvest.py
+++ b/udata/migrations/2024-10-09-remove-extras-harvest.py
@@ -16,11 +16,7 @@ def migrate(db):
 
     datasets = (
         Dataset.objects(
-            __raw__={
-                "$or": [
-                    {"extras.harvest": {"$exists": True}},
-                ],
-            }
+            __raw__={"extras.harvest": {"$exists": True}},
         )
         .no_cache()
         .timeout(False)

--- a/udata/migrations/2024-10-09-remove-extras-harvest.py
+++ b/udata/migrations/2024-10-09-remove-extras-harvest.py
@@ -24,14 +24,9 @@ def migrate(db):
 
     datasets_count = datasets.count()
     for dataset in datasets:
-        dataset.extras = {
-            extra: dataset.extras[extra] for extra in dataset.extras if extra != "harvest"
-        }
+        dataset.extras.pop("harvest", None)
         for resource in dataset.resources:
-            resource.extras = {
-                extra: resource.extras[extra] for extra in resource.extras if extra != "harvest"
-            }
-
+            resource.extras.pop("harvest", None)
         try:
             dataset.save()
         except ValidationError as e:

--- a/udata/rdf.py
+++ b/udata/rdf.py
@@ -213,7 +213,7 @@ def serialize_value(value, parse_label=False):
         return value.identifier.toPython()
 
 
-def rdf_values(resource, predicate, parse_label=False) -> set[str]:
+def rdf_unique_values(resource, predicate, parse_label=False) -> set[str]:
     """Returns a set of serialized values for a predicate from a RdfResource"""
     return {
         value

--- a/udata/rdf.py
+++ b/udata/rdf.py
@@ -208,10 +208,8 @@ def serialize_value(value, parse_label=False):
     if isinstance(value, (URIRef, Literal)):
         return value.toPython()
     elif isinstance(value, RdfResource):
-        if parse_label:
-            rdfs_label = rdf_value(value, RDFS.label)
-            if rdfs_label:
-                return rdfs_label
+        if parse_label and (rdfs_label := rdf_value(value, RDFS.label)):
+            return rdfs_label
         return value.identifier.toPython()
 
 

--- a/udata/rdf.py
+++ b/udata/rdf.py
@@ -200,7 +200,7 @@ CONTEXT = {
 
 def serialize_value(value, parse_label=False):
     """
-    If the value is a URIRef, return it as a string.
+    If the value is a URIRef or a Literal, return it as a string.
     If the value is a RdfResource:
         - Return the label of the RdfResource if any and `parse_label`,
         - or the identifier of the RdfResource.


### PR DESCRIPTION
This extends the logic introduced in https://github.com/opendatateam/udata/pull/3054 and refactors quite a few things.

- store an array of detected `dct:license` at the resource and dataset level, in extras
- store an array of detected `dct:rights` at the resource and dataset level, in extras
- switch `dct:accessRights` cardinality to N (we now store a list) — the algorithm to assign it to a dataset is now : get the _common_ items from the lists of accessRights from the resources 
- use the new helper function to handle `dct:provenance`
- use a `dcat` namespace in `extras` to store all the above (makes more sense than `harvest`?) — a migration removes existing `extras["harvest"]`

The license detection logic stays the same as in https://github.com/opendatateam/udata/pull/3054: licenses and rights detected in resources and dataset are fed to the guess algorithm.

This should allow easier debugging (where does the dataset license comes from?) and ecologie.data.gouv.fr could choose to display the extra harvested informations.

This also refactors RDF parsing a bit: `rdf_value` has a `parse_label` arg — which avoids repetition, and `rdf_values` is introduced to fetch a set of values instead a single value. It simply iterates with `rdf_value`. I think we should work toward a unified RDF parsing logic instead of introducing subtly different ways for every predicate. That's why I made the effort. We're not there yet though ;-)

About cardinality:
- `dct:license` and `dct:accessRights` should be 1 max, but in practice we may find many (cf geo-ide), so we handle N
- `dct:rights` should be 1 max for now, but N later (DCAT 3) and it makes sense to handle it as license
