### PR TITLE
feat(harvest): Use organization instead of agent coordinates as contact point

### DIFF
--- a/udata/harvest/tests/test_dcat_backend.py
+++ b/udata/harvest/tests/test_dcat_backend.py
@@ -729,7 +729,10 @@ class DcatBackendTest(PytestOnlyDBTestCase):
         assert dataset.contact_points[0].email == "sav.bd@ign.fr"
         assert dataset.contact_points[0].role == "rightsHolder"
 
-        assert dataset.contact_points[1].name == "Administrateur de Données"
+        assert (
+            dataset.contact_points[1].name
+            == "Direction Régionale de l’Environnement de l’Aménagement et du Logement d'Auvergne-Rhône-Alpes (DREAL Auvergne-Rhône-Alpes)"
+        )
         assert dataset.contact_points[1].email == "sig.dreal-ara@developpement-durable.gouv.fr"
         assert dataset.contact_points[1].role == "user"
 
@@ -744,11 +747,14 @@ class DcatBackendTest(PytestOnlyDBTestCase):
         assert dataset is not None
         assert len(dataset.contact_points) == 3
 
-        assert dataset.contact_points[0].name == "Administrateur de Données"
+        assert (
+            dataset.contact_points[0].name
+            == "Direction Régionale de l’Environnement de l’Aménagement et du Logement d'Auvergne-Rhône-Alpes (DREAL Auvergne-Rhône-Alpes)"
+        )
         assert dataset.contact_points[0].email == "sig.dreal-ara@developpement-durable.gouv.fr"
         assert dataset.contact_points[0].role == "contact"
 
-        assert dataset.contact_points[1].name == "Jean-Michel GENIS"
+        assert dataset.contact_points[1].name == "Conservatoire Botanique National Alpin"
         assert dataset.contact_points[1].email == "jm.genis@cbn-alpin.fr"
         assert dataset.contact_points[1].role == "rightsHolder"
 

--- a/udata/rdf.py
+++ b/udata/rdf.py
@@ -12,6 +12,7 @@ from rdflib import BNode, Graph, Literal, URIRef
 from rdflib.namespace import (
     DCTERMS,
     FOAF,
+    ORG,
     RDF,
     RDFS,
     SKOS,
@@ -369,7 +370,11 @@ def contact_points_from_rdf(rdf, prop, role, dataset):
             email = None
             contact_form = None
         elif prop == DCAT.contactPoint:  # Could be split on the type of contact_point instead
-            name = rdf_value(contact_point, VCARD.fn) or ""
+            name = (
+                rdf_value(contact_point, VCARD["organization-name"])
+                or rdf_value(contact_point, VCARD.fn)
+                or ""
+            )
             email = (
                 rdf_value(contact_point, VCARD.hasEmail)
                 or rdf_value(contact_point, VCARD.email)
@@ -378,12 +383,18 @@ def contact_points_from_rdf(rdf, prop, role, dataset):
             email = email.replace("mailto:", "").strip() if email else None
             contact_form = rdf_value(contact_point, VCARD.hasUrl)
         else:
+            contact_point_org = contact_point.value(ORG.memberOf)
             name = (
-                rdf_value(contact_point, FOAF.name)
+                (contact_point_org and rdf_value(contact_point_org, FOAF.name))
+                or rdf_value(contact_point, FOAF.name)
                 or rdf_value(contact_point, SKOS.prefLabel)
                 or ""
             )
-            email = rdf_value(contact_point, FOAF.mbox)
+            email = (
+                (contact_point_org and rdf_value(contact_point_org, FOAF.mbox))
+                or rdf_value(contact_point, FOAF.mbox)
+                or None
+            )
             email = email.replace("mailto:", "").strip() if email else None
             contact_form = None
 

--- a/udata/tests/dataset/test_dataset_rdf.py
+++ b/udata/tests/dataset/test_dataset_rdf.py
@@ -639,7 +639,7 @@ class RdfToDatasetTest(PytestOnlyDBTestCase):
 
         assert len(dataset.contact_points) == 1
         assert dataset.contact_points[0].role == "contact"
-        assert dataset.contact_points[0].name == "foo"
+        assert dataset.contact_points[0].name == "bar"
         assert dataset.contact_points[0].email == "foo@example.com"
 
     def test_contact_point_organization_member_foaf(self):
@@ -669,8 +669,8 @@ class RdfToDatasetTest(PytestOnlyDBTestCase):
 
         assert len(dataset.contact_points) == 1
         assert dataset.contact_points[0].role == "creator"
-        assert dataset.contact_points[0].name == "foo"
-        assert dataset.contact_points[0].email == "foo@example.com"
+        assert dataset.contact_points[0].name == "bar"
+        assert dataset.contact_points[0].email == "bar@example.com"
 
     def test_contact_point_organization_member_foaf_no_mail(self):
         g = Graph()
@@ -699,7 +699,7 @@ class RdfToDatasetTest(PytestOnlyDBTestCase):
 
         assert len(dataset.contact_points) == 1
         assert dataset.contact_points[0].role == "creator"
-        assert dataset.contact_points[0].name == "foo"
+        assert dataset.contact_points[0].name == "bar"
         assert dataset.contact_points[0].email == "foo@example.com"
 
     def test_theme_and_tags(self):


### PR DESCRIPTION
When both individual and organization info is available, store org info.

See https://github.com/opendatateam/udata/pull/3374#discussion_r2263423257 for context.
